### PR TITLE
Updated Nodejs runtime to 8.10 for Lambda Functions

### DIFF
--- a/AWSDevOpsTutorialCloudFormationStack.json
+++ b/AWSDevOpsTutorialCloudFormationStack.json
@@ -836,7 +836,7 @@
                     },
                     "S3Key": "lambdas.zip"
                 },
-                "Runtime": "nodejs6.10",
+                "Runtime": "nodejs8.10",
                 "Timeout": "120",
                 "TracingConfig": {
                     "Mode": "PassThrough"
@@ -860,7 +860,7 @@
                     },
                     "S3Key": "lambdas.zip"
                 },
-                "Runtime": "nodejs6.10",
+                "Runtime": "nodejs8.10",
                 "Timeout": "120",
                 "TracingConfig": {
                     "Mode": "PassThrough"
@@ -884,7 +884,7 @@
                     },
                     "S3Key": "lambdas.zip"
                 },
-                "Runtime": "nodejs6.10",
+                "Runtime": "nodejs8.10",
                 "Timeout": "120",
                 "TracingConfig": {
                     "Mode": "PassThrough"
@@ -908,7 +908,7 @@
                     },
                     "S3Key": "lambdas.zip"
                 },
-                "Runtime": "nodejs6.10",
+                "Runtime": "nodejs8.10",
                 "Timeout": "120",
                 "TracingConfig": {
                     "Mode": "PassThrough"
@@ -932,7 +932,7 @@
                     },
                     "S3Key": "lambdas.zip"
                 },
-                "Runtime": "nodejs6.10",
+                "Runtime": "nodejs8.10",
                 "Timeout": "120",
                 "TracingConfig": {
                     "Mode": "PassThrough"
@@ -956,7 +956,7 @@
                     },
                     "S3Key": "lambdas.zip"
                 },
-                "Runtime": "nodejs6.10",
+                "Runtime": "nodejs8.10",
                 "Timeout": "120",
                 "TracingConfig": {
                     "Mode": "PassThrough"


### PR DESCRIPTION
I received an email from AWS stating they will be EOL-ing node 6.10 for Lambda in the next month.  I've updated the nodejs runtime in the CloudFormation script to use nodejs8.10 runtime.  I've tested that the functions still execute correctly by going through the lab and deploying multiple app builds and re-running the pipeline, with all events executing as expected.

For context here is the email the received from AWS describing the EOL of nodejs6.10 runtime:

> Hello,
> 
> Your AWS Account currently has one or more Lambda functions using the node.js 6.10 runtime. The Node Foundation has previously published that node.js 6.x "Boron" will be declared End-of-Life (EOL) on April 2019 [1], and will stop receiving bug fixes, security updates, or performance improvements. Per the AWS Lambda runtime support policy [2], language runtimes that have reached their EOL are deprecated in AWS Lambda.
> 
> Invokes for functions configured to run on node.js 6.10 will continue to work normally, however the ability to create new Lambda functions configured to use the node.js 6.10 runtime will be disabled on April 30 2019. Code updates to existing functions using node.js 6.10 will be disabled 30 days later on May 30 2019
> 
> We encourage you to update your node.js 6.10 functions to a newer version of the Node runtime (node.js 8.10) so that you continue to benefit from important security, performance, and functionality enhancements offered by more recent releases. The newer node.js 8.10 version has improved ECMAScript support, along with other language and API improvements. The AWS Lambda programming model [3] for node.js 8.10 maintains backwards compatibility with previous versions to simplify portability. We recommend that you test your Lambda function to validate its behavior on the newer version of Node.js.
> 
> Should you have any questions or concerns please contact AWS Support [4].
> 
> [1] Node Foundation’s announcement of EOL: https://nodejs.org/en/blog/release/v6.9.0/
> [2] AWS Lambda runtime support policy: https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html
> [3] Using the AWS Lambda node.js 8.10 runtime: https://aws.amazon.com/blogs/compute/node-js-8-10-runtime-now-available-in-aws-lambda/
> [4] AWS Support: https://aws.amazon.com/support
> 
> Sincerely,
> Amazon Web Services

