### PR TITLE
Updated nodejs8.x to nodejs12.x

### DIFF
--- a/AWSDevOpsTutorialCloudFormationStack.json
+++ b/AWSDevOpsTutorialCloudFormationStack.json
@@ -836,7 +836,7 @@
                     },
                     "S3Key": "lambdas.zip"
                 },
-                "Runtime": "nodejs8.10",
+                "Runtime": "nodejs12.x",
                 "Timeout": "120",
                 "TracingConfig": {
                     "Mode": "PassThrough"
@@ -860,7 +860,7 @@
                     },
                     "S3Key": "lambdas.zip"
                 },
-                "Runtime": "nodejs8.10",
+                "Runtime": "nodejs12.x",
                 "Timeout": "120",
                 "TracingConfig": {
                     "Mode": "PassThrough"
@@ -884,7 +884,7 @@
                     },
                     "S3Key": "lambdas.zip"
                 },
-                "Runtime": "nodejs8.10",
+                "Runtime": "nodejs12.x",
                 "Timeout": "120",
                 "TracingConfig": {
                     "Mode": "PassThrough"
@@ -908,7 +908,7 @@
                     },
                     "S3Key": "lambdas.zip"
                 },
-                "Runtime": "nodejs8.10",
+                "Runtime": "nodejs12.x",
                 "Timeout": "120",
                 "TracingConfig": {
                     "Mode": "PassThrough"
@@ -932,7 +932,7 @@
                     },
                     "S3Key": "lambdas.zip"
                 },
-                "Runtime": "nodejs8.10",
+                "Runtime": "nodejs12.x",
                 "Timeout": "120",
                 "TracingConfig": {
                     "Mode": "PassThrough"
@@ -956,7 +956,7 @@
                     },
                     "S3Key": "lambdas.zip"
                 },
-                "Runtime": "nodejs8.10",
+                "Runtime": "nodejs12.x",
                 "Timeout": "120",
                 "TracingConfig": {
                     "Mode": "PassThrough"


### PR DESCRIPTION
Updated nodejs8.x to nodejs12.x due to support running out on Lambda on Feb 3rd, 2020 